### PR TITLE
Marshalling Support for Vultr Object 

### DIFF
--- a/lib/vultr/object.rb
+++ b/lib/vultr/object.rb
@@ -1,18 +1,11 @@
 require "ostruct"
+require "delegate"
+require "json"
 
 module Vultr
-  class Object
+  class Object < SimpleDelegator
     def initialize(attributes)
-      @attributes = OpenStruct.new(attributes)
-    end
-
-    def method_missing(method, *args, &block)
-      attribute = @attributes.send(method, *args, &block)
-      attribute.is_a?(Hash) ? Object.new(attribute) : attribute
-    end
-
-    def respond_to_missing?(method, include_private = false)
-      true
+      super(JSON.parse(attributes.to_json, object_class: OpenStruct))
     end
   end
 end

--- a/test/vultr/object_test.rb
+++ b/test/vultr/object_test.rb
@@ -2,10 +2,10 @@ require "test_helper"
 
 class ObjectTest < Minitest::Test
   def test_creating_object_from_hash
-    assert_equal :bar, Vultr::Object.new(foo: :bar).foo
+    assert_equal "bar", Vultr::Object.new(foo: :bar).foo
   end
 
   def test_nested_hash
-    assert_equal :foobar, Vultr::Object.new(foo: {bar: {baz: :foobar}}).foo.bar.baz
+    assert_equal "foobar", Vultr::Object.new(foo: {bar: {baz: :foobar}}).foo.bar.baz
   end
 end

--- a/test/vultr/object_test.rb
+++ b/test/vultr/object_test.rb
@@ -8,4 +8,8 @@ class ObjectTest < Minitest::Test
   def test_nested_hash
     assert_equal "foobar", Vultr::Object.new(foo: {bar: {baz: :foobar}}).foo.bar.baz
   end
+
+  def test_nested_number
+    assert_equal 1, Vultr::Object.new(foo: {bar: 1}).foo.bar
+  end
 end


### PR DESCRIPTION
This PR changes `Vultr::Object` implementation to use Ruby's SimpleDelegator pattern to support `Rails.cache` and refactors hash to object code as suggested in [this StackOverflow answer](https://stackoverflow.com/a/35767927/927644)