### PR TITLE
Test Applications Resource

### DIFF
--- a/test/fixtures/applications/list.json
+++ b/test/fixtures/applications/list.json
@@ -1,0 +1,29 @@
+{
+  "applications": [
+    {
+      "id": 1,
+      "name": "LEMP",
+      "short_name": "lemp",
+      "deploy_name": "LEMP on CentOS 6 x64",
+      "type": "one-click",
+      "vendor": "vultr",
+      "image_id": ""
+    },
+    {
+      "id": 1028,
+      "name": "OpenLiteSpeed WordPress",
+      "short_name": "openlitespeedwordpress",
+      "deploy_name": "OpenLiteSpeed WordPress on Ubuntu 20.04 x64",
+      "type": "marketplace",
+      "vendor": "LiteSpeed_Technologies",
+      "image_id": "openlitespeed-wordpress"
+    }
+  ],
+  "meta": {
+    "total": 2,
+    "links": {
+      "next": "",
+      "prev": ""
+    }
+  }
+}

--- a/test/vultr/resources/applications_test.rb
+++ b/test/vultr/resources/applications_test.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class ApplicationsResourceTest < Minitest::Test
+  def test_list
+    stub = stub_request("applications", response: stub_response(fixture: "applications/list"))
+    client = Vultr::Client.new(api_key: "fake", adapter: :test, stubs: stub)
+    applications = client.applications.list
+
+    assert_equal Vultr::Collection, applications.class
+    assert_equal Vultr::Application, applications.data.first.class
+    assert_equal 2, applications.total
+  end
+end


### PR DESCRIPTION
- Add test for the [Applications Resource](https://www.vultr.com/api/#operation/list-applications) based on `UsersResourceTest#list`. 
- Add `test/fixtures/applications/list.json` which was directly copied from [the Vultr Docs](https://www.vultr.com/api/#operation/list-applications).