### PR TITLE
Test Backups Resource

### DIFF
--- a/test/fixtures/backups/list.json
+++ b/test/fixtures/backups/list.json
@@ -1,0 +1,18 @@
+{
+  "backups": [
+    {
+      "id": "cb676a46-66fd-4dfb-b839-443f2e6c0b60",
+      "date_created": "2020-10-10T01:56:20+00:00",
+      "description": "Example Automatic Backup",
+      "size": 10000000,
+      "status": "complete"
+    }
+  ],
+  "meta": {
+    "total": 1,
+    "links": {
+      "next": "",
+      "prev": ""
+    }
+  }
+}

--- a/test/fixtures/backups/retrieve.json
+++ b/test/fixtures/backups/retrieve.json
@@ -1,0 +1,9 @@
+{
+  "backup": {
+    "id": "cb676a46-66fd-4dfb-b839-443f2e6c0b60",
+    "date_created": "2020-10-10T01:56:20+00:00",
+    "description": "Example Description",
+    "size": 10000000,
+    "status": "complete"
+  }
+}

--- a/test/vultr/resources/backups_test.rb
+++ b/test/vultr/resources/backups_test.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class BackupsResourceTest < Minitest::Test
+  def test_list
+    stub = stub_request("backups", response: stub_response(fixture: "backups/list"))
+    client = Vultr::Client.new(api_key: "fake", adapter: :test, stubs: stub)
+    backups = client.backups.list
+    assert_equal Vultr::Collection, backups.class
+    assert_equal Vultr::Backup, backups.data.first.class
+    assert_equal 1, backups.total
+  end
+
+  def test_retrieve
+    backup_id = "cb676a46-66fd-4dfb-b839-443f2e6c0b60"
+    stub = stub_request("backups/#{backup_id}", response: stub_response(fixture: "backups/retrieve"))
+    client = Vultr::Client.new(api_key: "fake", adapter: :test, stubs: stub)
+    backup = client.backups.retrieve(backup_id: backup_id)
+
+    assert_equal Vultr::Backup, backup.class
+    assert_equal "complete", backup.status
+  end
+end


### PR DESCRIPTION
- Add test for the [Backups Resource](https://www.vultr.com/api/#tag/backup) based on `UsersResourceTest`. 
- Add `test/fixtures/backups/list.json` and `test/fixtures/backups/retrieve.json` which was directly copied from [the Vultr Docs](https://www.vultr.com/api/#tag/backup).