### PR TITLE
Use Faraday middleware to include Authorization header (#23)

### DIFF
--- a/lib/vultr/client.rb
+++ b/lib/vultr/client.rb
@@ -97,8 +97,8 @@ module Vultr
     end
 
     def connection
-      @connection ||= Faraday.new do |conn|
-        conn.url_prefix = BASE_URL
+      @connection ||= Faraday.new(BASE_URL) do |conn|
+        conn.request :authorization, :Bearer, api_key
         conn.request :json
         conn.response :json, content_type: "application/json"
         conn.adapter adapter, @stubs

--- a/lib/vultr/resource.rb
+++ b/lib/vultr/resource.rb
@@ -9,27 +9,23 @@ module Vultr
     private
 
     def get_request(url, params: {}, headers: {})
-      handle_response client.connection.get(url, params, default_headers.merge(headers))
+      handle_response client.connection.get(url, params, headers)
     end
 
     def post_request(url, body:, headers: {})
-      handle_response client.connection.post(url, body, default_headers.merge(headers))
+      handle_response client.connection.post(url, body, headers)
     end
 
     def patch_request(url, body:, headers: {})
-      handle_response client.connection.patch(url, body, default_headers.merge(headers))
+      handle_response client.connection.patch(url, body, headers)
     end
 
     def put_request(url, body:, headers: {})
-      handle_response client.connection.put(url, body, default_headers.merge(headers))
+      handle_response client.connection.put(url, body, headers)
     end
 
     def delete_request(url, params: {}, headers: {})
-      handle_response client.connection.delete(url, params, default_headers.merge(headers))
-    end
-
-    def default_headers
-      {Authorization: "Bearer #{client.api_key}"}
+      handle_response client.connection.delete(url, params, headers)
     end
 
     def handle_response(response)


### PR DESCRIPTION
* Use OAuth2 middleware to include Authorization header

* Add Authorization header to client configuration

Adding directly instead of using the OAuth2 middleware since this gem technically doesn't use OAuth.

* Remove default_headers method

It's no longer needed now that we set the Authorization header in Faraday.

Co-authored-by: Chris Oliver <excid3@gmail.com>